### PR TITLE
chore: use a name variable to override promise

### DIFF
--- a/lib/n1ql.js
+++ b/lib/n1ql.js
@@ -5,8 +5,8 @@ const createError = require('http-errors');
 const N1qlQuery = require('couchbase').N1qlQuery;
 const getFieldName = require('./tokenizer');
 const util = require('util');
-global.Promise = require('bluebird');
-
+const Promise = require('bluebird');
+global.Promise = Promise;
 const symbols = {
   nlike: 'NOT LIKE',
   like: 'LIKE',

--- a/lib/n1ql.js
+++ b/lib/n1ql.js
@@ -7,6 +7,7 @@ const getFieldName = require('./tokenizer');
 const util = require('util');
 const Promise = require('bluebird');
 global.Promise = Promise;
+
 const symbols = {
   nlike: 'NOT LIKE',
   like: 'LIKE',


### PR DESCRIPTION
seems the issue is still not resolved, might be because bluebird isn't explicitly declared to a variable before trying to override 